### PR TITLE
Add custom server to options (:server => 'thin').

### DIFF
--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -12,7 +12,8 @@ module Guard
         :environment => 'development',
         :start_on_start => true,
         :force_run => false,
-        :timeout => 20
+        :timeout => 20,
+        :server => nil
       }
 
     def initialize(watchers = [], options = {})
@@ -23,7 +24,8 @@ module Guard
     end
 
     def start
-      UI.info "Guard::Rails will now restart your app on port #{options[:port]} using #{options[:environment]} environment."
+      server = options[:server] ? "#{options[:server]} and " : ""
+      UI.info "Guard::Rails will now restart your app on port #{options[:port]} using #{server}#{options[:environment]} environment."
       run_all if options[:start_on_start]
     end
 

--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -37,6 +37,7 @@ module Guard
       ]
 
       rails_options << '-d' if options[:daemon]
+      rails_options << options[:server] if options[:server]
 
       %{sh -c 'cd #{Dir.pwd} && rails s #{rails_options.join(' ')} &'}
     end

--- a/spec/lib/guard/rails/runner_spec.rb
+++ b/spec/lib/guard/rails/runner_spec.rb
@@ -46,6 +46,14 @@ describe Guard::RailsRunner do
         runner.build_rails_command.should match(%r{ -d})
       end
     end
+
+    context 'custom server' do
+      let(:options) { default_options.merge(:server => 'thin') }
+
+      it "should have the server name" do
+        runner.build_rails_command.should match(%r{thin})
+      end
+    end
   end
 
   describe '#start' do


### PR DESCRIPTION
Ability to specify which server to run Rails with.
