### PR TITLE
Reload instead of run_all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.rvmrc

--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -26,10 +26,10 @@ module Guard
     def start
       server = options[:server] ? "#{options[:server]} and " : ""
       UI.info "Guard::Rails will now restart your app on port #{options[:port]} using #{server}#{options[:environment]} environment."
-      run_all if options[:start_on_start]
+      reload if options[:start_on_start]
     end
 
-    def run_all
+    def reload
       UI.info "Restarting Rails..."
       Notifier.notify("Rails restarting on port #{options[:port]} in #{options[:environment]} environment...", :title => "Restarting Rails...", :image => :pending)
       if runner.restart
@@ -41,15 +41,13 @@ module Guard
       end
     end
 
-    alias :reload :run_all
-
     def stop
       Notifier.notify("Until next time...", :title => "Rails shutting down.", :image => :pending)
       runner.stop
     end
 
     def run_on_change(paths)
-      run_all
+      reload
     end
   end
 end

--- a/spec/lib/guard/rails_spec.rb
+++ b/spec/lib/guard/rails_spec.rb
@@ -19,7 +19,7 @@ describe Guard::Rails do
 
     context 'start on start' do
       it "should show the right message and run startup" do
-        guard.expects(:run_all).once
+        guard.expects(:reload).once
         ui_expectation
         guard.start
       end
@@ -29,14 +29,14 @@ describe Guard::Rails do
       let(:options) { { :start_on_start => false } }
 
       it "should show the right message and not run startup" do
-        guard.expects(:run_all).never
+        guard.expects(:reload).never
         ui_expectation
         guard.start
       end
     end
   end
 
-  describe '#run_all' do
+  describe '#reload' do
     let(:pid) { '12345' }
 
     before do
@@ -56,7 +56,7 @@ describe Guard::Rails do
         Guard::UI.expects(:info).with(regexp_matches(/#{pid}/))
         Guard::Notifier.expects(:notify).with(regexp_matches(/Rails restarted/), has_entry(:image => :success))
 
-        guard.run_all
+        guard.reload
       end
     end
 
@@ -70,11 +70,11 @@ describe Guard::Rails do
         Guard::UI.expects(:info).with(regexp_matches(/Rails NOT restarted/))
         Guard::Notifier.expects(:notify).with(regexp_matches(/Rails NOT restarted/), has_entry(:image => :failed))
 
-        guard.run_all
+        guard.reload
       end
     end
   end
-  
+
   describe '#stop' do
     it "should stop correctly" do
       Guard::Notifier.expects(:notify).with('Until next time...', anything)
@@ -83,8 +83,8 @@ describe Guard::Rails do
   end
 
   describe '#run_on_change' do
-    it "should run on change" do
-      guard.expects(:run_all).once
+    it "should reload on change" do
+      guard.expects(:reload).once
       guard.run_on_change([])
     end
   end


### PR DESCRIPTION
Hi John,

This is what I meant regarding [issue 6](https://github.com/johnbintz/guard-rails/issues/6).

I've replaced run_all with reload so when a user hits return, nothing happens, but when they hit r+return the rails server restarts. This means you can use return to just run all tests, and r+return to restart rails, spork etc...

Any watched files will restart rails when touched, the same way it happens now.

What do you think? Does that work for you?
