### PR TITLE
Changed notifications at start to say "Rails starting..." instead of "Rails restarting..."

### DIFF
--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -27,18 +27,19 @@ module Guard
     def start
       server = options[:server] ? "#{options[:server]} and " : ""
       UI.info "Guard::Rails will now restart your app on port #{options[:port]} using #{server}#{options[:environment]} environment."
-      reload if options[:start_on_start]
+      reload("start") if options[:start_on_start]
     end
 
-    def reload
-      UI.info "Restarting Rails..."
-      Notifier.notify("Rails restarting on port #{options[:port]} in #{options[:environment]} environment...", :title => "Restarting Rails...", :image => :pending)
+    def reload(action = "restart")
+      action_cap = action.capitalize
+      UI.info "#{action_cap}ing Rails..."
+      Notifier.notify("Rails #{action}ing on port #{options[:port]} in #{options[:environment]} environment...", :title => "#{action_cap}ing Rails...", :image => :pending)
       if runner.restart
-        UI.info "Rails restarted, pid #{runner.pid}"
-        Notifier.notify("Rails restarted on port #{options[:port]}.", :title => "Rails restarted!", :image => :success)
+        UI.info "Rails #{action}ed, pid #{runner.pid}"
+        Notifier.notify("Rails #{action}ed on port #{options[:port]}.", :title => "Rails #{action}ed!", :image => :success)
       else
-        UI.info "Rails NOT restarted, check your log files."
-        Notifier.notify("Rails NOT restarted, check your log files.", :title => "Rails NOT restarted!", :image => :failed)
+        UI.info "Rails NOT #{action}ed, check your log files."
+        Notifier.notify("Rails NOT #{action}ed, check your log files.", :title => "Rails NOT #{action}ed!", :image => :failed)
       end
     end
 

--- a/spec/lib/guard/rails_spec.rb
+++ b/spec/lib/guard/rails_spec.rb
@@ -40,37 +40,58 @@ describe Guard::Rails do
     let(:pid) { '12345' }
 
     before do
-      Guard::UI.expects(:info).with('Restarting Rails...')
-      Guard::Notifier.expects(:notify).with(regexp_matches(/Rails restarting/), has_entry(:image => :pending))
       Guard::RailsRunner.any_instance.stubs(:pid).returns(pid)
     end
 
     let(:runner_stub) { Guard::RailsRunner.any_instance.stubs(:restart) }
 
-    context 'with pid file' do
+    context 'at start' do
       before do
+        Guard::UI.expects(:info).with('Starting Rails...')
+        Guard::Notifier.expects(:notify).with(regexp_matches(/Rails starting/), has_entry(:image => :pending))
         runner_stub.returns(true)
       end
 
-      it "should restart and show the pid file" do
+      it "should start and show the pid file" do
         Guard::UI.expects(:info).with(regexp_matches(/#{pid}/))
-        Guard::Notifier.expects(:notify).with(regexp_matches(/Rails restarted/), has_entry(:image => :success))
+        Guard::Notifier.expects(:notify).with(regexp_matches(/Rails started/), has_entry(:image => :success))
 
-        guard.reload
+        guard.reload("start")
       end
     end
 
-    context 'no pid file' do
+    context 'after start' do
       before do
-        runner_stub.returns(false)
+        Guard::RailsRunner.any_instance.stubs(:pid).returns(pid)
+        Guard::UI.expects(:info).with('Restarting Rails...')
+        Guard::Notifier.expects(:notify).with(regexp_matches(/Rails restarting/), has_entry(:image => :pending))
       end
 
-      it "should restart and show the pid file" do
-        Guard::UI.expects(:info).with(regexp_matches(/#{pid}/)).never
-        Guard::UI.expects(:info).with(regexp_matches(/Rails NOT restarted/))
-        Guard::Notifier.expects(:notify).with(regexp_matches(/Rails NOT restarted/), has_entry(:image => :failed))
+      context 'with pid file' do
+        before do
+          runner_stub.returns(true)
+        end
 
-        guard.reload
+        it "should restart and show the pid file" do
+          Guard::UI.expects(:info).with(regexp_matches(/#{pid}/))
+          Guard::Notifier.expects(:notify).with(regexp_matches(/Rails restarted/), has_entry(:image => :success))
+
+          guard.reload
+        end
+      end
+
+      context 'no pid file' do
+        before do
+          runner_stub.returns(false)
+        end
+
+        it "should restart and show the pid file" do
+          Guard::UI.expects(:info).with(regexp_matches(/#{pid}/)).never
+          Guard::UI.expects(:info).with(regexp_matches(/Rails NOT restarted/))
+          Guard::Notifier.expects(:notify).with(regexp_matches(/Rails NOT restarted/), has_entry(:image => :failed))
+
+          guard.reload
+        end
       end
     end
   end


### PR DESCRIPTION
Changed notifications at start to say "Rails starting..." and "Rails started!" instead of "restarting".
Added a test for it, too
