### PR TITLE
stop server with SIGINT

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -18,9 +18,9 @@ module Guard
 
     def stop
       if File.file?(pid_file)
-        system %{kill -KILL #{File.read(pid_file).strip}}
+        system %{kill -SIGINT #{File.read(pid_file).strip}}
         wait_for_no_pid if $?.exitstatus == 0
-        FileUtils.rm pid_file
+        FileUtils.rm pid_file, :force => true
       end
     end
 


### PR DESCRIPTION
Not sure if this is just me, but using KILL to stop the server doesn't clean up the pid. Using SIGINT allows the pid to be cleaned up and avoids a restart that takes 30 seconds.

Ruby 1.9.2 and webrick
