### PR TITLE
Ensure specified environment is used

### DIFF
--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -40,7 +40,7 @@ module Guard
       rails_options << '-u' if options[:debugger]
       rails_options << options[:server] if options[:server]
 
-      %{sh -c 'cd #{Dir.pwd} && rails s #{rails_options.join(' ')} &'}
+      %{sh -c 'cd #{Dir.pwd} && RAILS_ENV=#{options[:environment]} rails s #{rails_options.join(' ')} &'}
     end
 
     def pid_file


### PR DESCRIPTION
If for any reason RAILS_ENV was set to test this command will start a
Rails server with test environment:

```
rails s -e development
```

But this one will start with development environment:

```
RAILS_ENV=development rails s
```

I am not sure who is at fault here, but this ensures guard-rails will
always use the environment specified by the environment option.
