### PR TITLE
Added rails_root option for engine support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Lots of fun options!
 * `:debugger` runs the server with the debugger enabled (default `false`). Required ruby-debug gem.
 * `:timeout` waits this number of seconds when restarting the Rails server before reporting there's a problem (default `20`).
 * `:server` lets you specify the webserver engine to use (try `:server => :thin`).
+* `:rails_root` lets you specify the root directory of your app (try `:rails_root => 'test/dummy` for engines).
 
 This is super-alpha, but it works for me! Only really hand-tested in Mac OS X. Feel free to fork'n'fix for other
 OSes, and to add some more real tests.

--- a/lib/guard/rails.rb
+++ b/lib/guard/rails.rb
@@ -14,7 +14,8 @@ module Guard
         :force_run => false,
         :timeout => 30,
         :server => nil,
-        :debugger => false
+        :debugger => false,
+        :rails_root => nil
       }
 
     def initialize(watchers = [], options = {})

--- a/lib/guard/rails/runner.rb
+++ b/lib/guard/rails/runner.rb
@@ -40,11 +40,19 @@ module Guard
       rails_options << '-u' if options[:debugger]
       rails_options << options[:server] if options[:server]
 
-      %{sh -c 'cd #{Dir.pwd} && RAILS_ENV=#{options[:environment]} rails s #{rails_options.join(' ')} &'}
+      %{sh -c 'cd #{build_rails_path} && RAILS_ENV=#{options[:environment]} rails s #{rails_options.join(' ')} &'}
+    end
+    
+    def build_rails_path
+      if options[:rails_root]
+        File.join(Dir.pwd, options[:rails_root])
+      else  
+        Dir.pwd
+      end
     end
 
     def pid_file
-      File.expand_path("tmp/pids/#{options[:environment]}.pid")
+      File.expand_path(File.join(options[:rails_root].to_s, "tmp/pids/#{options[:environment]}.pid"))
     end
 
     def pid

--- a/spec/lib/guard/rails/runner_spec.rb
+++ b/spec/lib/guard/rails/runner_spec.rb
@@ -63,6 +63,14 @@ describe Guard::RailsRunner do
         runner.build_rails_command.should match(%r{thin})
       end
     end
+    
+    context 'custom app path' do
+      let(:options) { default_options.merge(:app_path => 'spec/dummy') }
+
+      it "should have the app path" do
+        runner.build_rails_command.should match(%r{spec/dummy})
+      end
+    end    
   end
 
   describe '#start' do


### PR DESCRIPTION
This should solve https://github.com/johnbintz/guard-rails/issues/16

See the updated README:
- `:rails_root` lets you specify the root directory of your app (try `:rails_root => 'test/dummy` for engines).
